### PR TITLE
Add ddf helm chart

### DIFF
--- a/helm/ddf/.helmignore
+++ b/helm/ddf/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/ddf/Chart.yaml
+++ b/helm/ddf/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: ddf
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 2.24.0

--- a/helm/ddf/templates/NOTES.txt
+++ b/helm/ddf/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ddf.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "ddf.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "ddf.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "ddf.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm/ddf/templates/_helpers.tpl
+++ b/helm/ddf/templates/_helpers.tpl
@@ -1,0 +1,200 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ddf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ddf.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ddf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ddf.labels" -}}
+helm.sh/chart: {{ include "ddf.chart" . }}
+{{ include "ddf.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ddf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ddf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ddf.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ddf.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* 
+Generate the hostaliases for the ddf
+*/}}
+{{- define "ddf.spec.hostAlias" -}}
+{{- if .hostname -}}
+hostAliases:
+  - ip: '127.0.0.1'
+    hostnames:
+      - {{ .hostname }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the volume configuration for any trusted certificates
+*/}}
+{{- define "ddf.trustedCertsVol" -}}
+- name: trusted-certs-vol
+  configMap:
+      name: {{ .Values.trustedCertsConfigName }}
+      defaultMode: 0644
+{{- end -}}
+
+{{/*
+Create the volume mount for any trusted certificates
+*/}}
+{{- define "ddf.trustedCertsMount" -}}
+{{- if hasKey $.Values "trustedCertsConfigName" -}}
+- name: trusted-certs-vol
+  mountPath: /trusted_certs
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate environment variables for injecting tls certs.
+*/}}
+{{- define "ddf.env.tls" -}}
+{{- if and .secret.name .ca.name }}
+- name: SSL_CERT
+  valueFrom:
+    secretKeyRef: 
+      name: {{ .secret.name }}
+      key: {{ .secret.certKey }}
+- name: SSL_KEY
+  valueFrom:
+    secretKeyRef: 
+      name: {{ .secret.name }}
+      key: {{ .secret.keyKey }}
+- name: SSL_CA_BUNDLE
+  valueFrom:
+    configMapKeyRef: 
+      name: {{ .ca.name }}
+      key: {{ .ca.caKey }}
+{{ end -}}
+{{- end -}}
+
+{{/*
+Generate environment variable for security profile
+*/}}
+{{- define "ddf.env.securityProfile" -}}
+{{- if .securityProfile }}
+- name: SECURITY_PROFILE
+  value: {{ .securityProfile.name }}
+{{ end -}}
+{{- end -}}
+
+{{/*
+Generate the environment variable for the install profile
+*/}}
+{{- define "ddf.env.installProfile" -}}
+{{- if .installProfile }}
+- name: INSTALL_PROFILE
+  value: {{ .installProfile }}
+{{ end -}}
+{{- end -}}
+
+{{/*
+Generate environment variables for hostname settings
+*/}}
+{{- define "ddf.env.hostname" -}}
+{{- if .hostname }}
+- name: EXTERNAL_HOSTNAME
+  value: {{ .Values.hostname }}
+  value: {{ .Values.hostname }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Generate environment variables for port settings
+*/}}
+{{- define "ddf.env.ports" -}}
+- name: EXTERNAL_HTTPS_PORT
+  value: '443'
+- name: EXTERNAL_HTTP_PORT
+  value: '80'
+{{- end -}}
+
+{{/*
+Generate environment variables for memory settings
+TODO: Need to support multiple memory formats, not just Gi - oconnormi
+*/}}
+{{- define "ddf.env.memory" -}}
+{{- if .resources.limits }}
+{{- if .resources.limits.memory }}
+- name: JAVA_MAX_MEM
+  value: '{{ trimSuffix "Gi" .resources.limits.memory }}'
+{{ end -}}
+{{ end -}}
+{{- end -}}
+
+{{/*
+Generate environment variables for ssh endpoint config
+TODO: Need to link this setting to something in the values file - oconnormi
+*/}}
+{{- define "ddf.env.ssh" -}}
+- name: SSH_ENABLED
+  value: 'true'
+{{- end -}}
+
+{{/*
+Generate environment variables for security manager configuration
+TODO: Need to link this setting to something in the values file - oconnormi
+*/}}
+{{- define "ddf.env.securityManager" -}}
+- name: SECURITY_MANAGER_DISABLED
+  value: 'true'
+{{- end -}}
+
+{{/*
+Generate environment variables for site name
+*/}}
+{{- define "ddf.env.siteName" -}}
+{{- if .siteName }}
+- name: SITE_NAME
+  value: {{ .siteName }}
+{{ end -}}
+{{- end -}}

--- a/helm/ddf/templates/config.yaml
+++ b/helm/ddf/templates/config.yaml
@@ -1,0 +1,14 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "ddf.fullname" . }}-config-directory
+  labels:
+    {{- include "ddf.labels" . | nindent 4 }}
+data:
+  org.apache.felix.fileinstall-config.cfg: |
+    felix.fileinstall.poll = 1000
+    felix.fileinstall.log.level = 3
+    felix.fileinstall.active.level = 80
+    felix.fileinstall.dir = /config
+    felix.fileinstall.start.level = 80
+    felix.fileinstall.tmpdir = /app/data/generated-bundles

--- a/helm/ddf/templates/deployment.yaml
+++ b/helm/ddf/templates/deployment.yaml
@@ -1,0 +1,87 @@
+{{- $fullname := include "ddf.fullname" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullname }}
+  labels:
+    {{- include "ddf.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "ddf.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "ddf.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "ddf.spec.hostAlias" .Values | nindent 6 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ddf.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          stdin: true
+          tty: true
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8181
+              protocol: TCP
+            - name: https
+              containerPort: 8993
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          env:
+            {{- include "ddf.env.tls" .Values.tls | nindent 16 }}
+            {{- include "ddf.env.securityProfile" .Values | nindent 16 }}
+            {{- include "ddf.env.installProfile" .Values | nindent 16 }}
+            {{- include "ddf.env.hostname" .Values | nindent 16 }}
+            {{- include "ddf.env.ports" .Values | nindent 16 }}
+            {{- include "ddf.env.memory" .Values | nindent 16 }}
+            {{- include "ddf.env.ssh" .Values | nindent 16 }}
+            {{- include "ddf.env.securityManager" .Values | nindent 16 }}
+            {{- include "ddf.env.memory" .Values | nindent 16 }}
+            {{- include "ddf.env.siteName" .Values | nindent 16 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config-directory
+              mountPath: /app/etc/org.apache.felix.fileinstall-config.cfg
+              subPath: org.apache.felix.fileinstall-config.cfg
+      volumes:
+        - name: sources-config-directory
+          configMap:
+            name: {{ $fullname }}-config-directory
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/ddf/templates/hpa.yaml
+++ b/helm/ddf/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ddf.fullname" . }}
+  labels:
+    {{- include "ddf.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ddf.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/helm/ddf/templates/ingress.yaml
+++ b/helm/ddf/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "ddf.fullname" . -}}
+{{- $svcPort := .Values.service.httpsPort -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "ddf.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm/ddf/templates/service.yaml
+++ b/helm/ddf/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ddf.fullname" . }}
+  labels:
+    {{- include "ddf.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.httpsPort }}
+      targetPort: https
+      protocol: TCP
+      name: https
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ddf.selectorLabels" . | nindent 4 }}

--- a/helm/ddf/templates/serviceaccount.yaml
+++ b/helm/ddf/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ddf.serviceAccountName" . }}
+  labels:
+    {{- include "ddf.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/ddf/templates/tests/test-connection.yaml
+++ b/helm/ddf/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "ddf.fullname" . }}-test-connection"
+  labels:
+    {{- include "ddf.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "ddf.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/ddf/values.yaml
+++ b/helm/ddf/values.yaml
@@ -1,0 +1,104 @@
+# Default values for ddf.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  registry: docker.io
+  repository: codice/ddf
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+hostname: ""
+installProfile: ""
+securityProfile:
+  name: ""
+
+tls:
+  secret:
+    # name of secret to use for injecting cert/key into ddf instance
+    # set the correct keys to match contents of the tls secret. defaults match what k8s uses by default
+    # name: ""
+    certKey: tls.crt
+    keyKey: tls.key
+
+  # ca is used to configure a configMap that contains the ca belongint to the tls key being used by the ddf instance
+  ca:
+    # change the name to the correct configMap when using injected certificates
+    # change the name of the key containing the ca if necessary
+    # name: ""
+    caKey: tls.ca-bundle
+  # ConfigMap name containing all private/custom CA certificates that need to be added to the truststore
+#  trustedCAs: ""
+  
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  httpsPort: 8993
+  httpPort: 8181
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
# DDF Helm Chart
Adds a helm chart for deploying a generic DDF workload

## Goals
* Support most common DDF concepts
* Build towards extensibility for downstream DDF projects

## Tasks
- [ ] Resolve Todos
- [ ] Add Chart Readme
- [ ] Add support for deploying solr cloud